### PR TITLE
Added back tiller namespace option for upgrade command. Now that main…

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -73,6 +73,10 @@ func setPushEventCommand(p *Plugin) {
 		upgrade = append(upgrade, "--namespace")
 		upgrade = append(upgrade, p.Config.Namespace)
 	}
+	if p.Config.TillerNs != "" {
+		upgrade = append(upgrade, "--tiller-namespace")
+		upgrade = append(upgrade, p.Config.TillerNs)
+	}
 	if p.Config.DryRun {
 		upgrade = append(upgrade, "--dry-run")
 	}


### PR DESCRIPTION
… branch is using Helm 2.2 this will work.