### PR TITLE
Add support to tag and deployment event

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -95,6 +95,10 @@ func setHelmCommand(p *Plugin) {
 	switch buildEvent {
 	case "push":
 		setPushEventCommand(p)
+	case "tag":
+		setPushEventCommand(p)
+	case "deployment":
+		setPushEventCommand(p)
 	case "delete":
 		setDeleteEventCommand(p)
 	default:


### PR DESCRIPTION
When using drone CLI to deploy a build, drone event is a "deployment" event. I have added "tag" event as well.