### PR TITLE
Reuse existing K8s config file

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,12 @@ func main() {
 			EnvVar: "PLUGIN_HELM_COMMAND,HELM_COMMAND",
 		},
 		cli.StringFlag{
+			Name:   "kube-config",
+			Usage:  "Kubernetes configuration file path",
+			EnvVar: "PLUGIN_KUBE_CONFIG,KUBE_CONFIG",
+			Value:  "/root/.kube/config",
+		},
+		cli.StringFlag{
 			Name:   "namespace",
 			Usage:  "Kubernetes namespace",
 			EnvVar: "PLUGIN_NAMESPACE,NAMESPACE",
@@ -133,6 +139,7 @@ func run(c *cli.Context) error {
 			APIServer:      c.String("api_server"),
 			Token:          c.String("token"),
 			ServiceAccount: c.String("service-account"),
+			KubeConfig:     c.String("kube-config"),
 			HelmCommand:    c.StringSlice("helm_command"),
 			Namespace:      c.String("namespace"),
 			SkipTLSVerify:  c.Bool("skip_tls_verify"),

--- a/plugin.go
+++ b/plugin.go
@@ -189,10 +189,18 @@ func (p *Plugin) Exec() error {
 }
 
 func initialiseKubeconfig(params *Config, source string, target string) error {
-	t, _ := template.ParseFiles(source)
-	f, err := os.Create(target)
-	err = t.Execute(f, params)
-	f.Close()
+	var err error
+	if _, err = os.Stat(target); os.IsNotExist(err) {
+		f, err := os.Create(target)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		// parse template
+		t, _ := template.ParseFiles(source)
+		// execute template
+		return t.Execute(f, params)
+	}
 	return err
 }
 


### PR DESCRIPTION
it will be very helpful to mount (when running in Docker) or reuse existing K8s config file

p.s. there are multiple options to authenticate against K8s cluster, and single template (used currently in drone-helm) cannot satisfy all flavors of configuration