### PR TITLE
Allow usage of this plugin during pull request

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -138,7 +138,7 @@ func setHelmCommand(p *Plugin) {
 		setDeleteCommand(p)
 	default:
 		switch os.Getenv("DRONE_BUILD_EVENT") {
-		case "push", "tag", "deployment":
+		case "push", "tag", "deployment", "pull_request":
 			setUpgradeCommand(p)
 		case "delete":
 			setDeleteCommand(p)


### PR DESCRIPTION
Hi,
All commits that belong to pull request will have such build event, therefore we will see only help message instead of deployment.

PS
Sorry, didn't know that my comments will go to commit message.