### PR TITLE
Drone rc release fix

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ pipeline:
     pull: true
     commands:
     - go get -u github.com/golang/dep/cmd/dep
-    - dep ensure
+    - dep ensure -update
 
   test:
     image: golang:1.10

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -149,7 +149,7 @@ func setHelmCommand(p *Plugin) {
 		setDeleteCommand(p)
 	default:
 		switch os.Getenv("DRONE_BUILD_EVENT") {
-		case "push", "tag", "deployment", "pull_request":
+		case "push", "tag", "deployment", "pull_request", "promote", "rollback":
 			setUpgradeCommand(p)
 		case "delete":
 			setDeleteCommand(p)


### PR DESCRIPTION
@ipedrazas Drone 1.0 is moving away from deployment and using promote and rollback.  This should keep it working with pre 1.0 and post 1.0