### PR TITLE
add symbols "@-" in repoExp

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -162,7 +162,7 @@ func setHelmCommand(p *Plugin) {
 
 }
 
-var repoExp = regexp.MustCompile(`^(?P<name>[\w-]+)=(?P<url>(http|https)://[\w-./:]+)`)
+var repoExp = regexp.MustCompile(`^(?P<name>[\w-]+)=(?P<url>(http|https)://[\w-./:@-]+)`)
 
 // parseRepo returns map of regex capture groups (name, url)
 func parseRepo(repo string) (map[string]string, error) {


### PR DESCRIPTION
If you want to use private github repository as helm repo, you should use link like `https://<token>@raw.githubusercontent.com/<repo>/<branch>`
So repoExp should content symbols @ and -