### PR TITLE
add lint command

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -139,7 +139,45 @@ func setUpgradeCommand(p *Plugin) {
 		upgrade = append(upgrade, "--force")
 	}
 	p.command = upgrade
+}
 
+func setLintCommand(p *Plugin) {
+	lint := make([]string, 2)
+	lint[0] = "lint"
+	lint[1] = p.Config.Chart
+
+	if p.Config.Values != "" {
+		lint = append(lint, "--set")
+		lint = append(lint, unQuote(p.Config.Values))
+	}
+
+	if p.Config.StringValues != "" {
+		lint = append(lint, "--set-string")
+		lint = append(lint, unQuote(p.Config.StringValues))
+	}
+
+	if p.Config.ValuesFiles != "" {
+		for _, valuesFile := range strings.Split(p.Config.ValuesFiles, ",") {
+			lint = append(lint, "--values")
+			lint = append(lint, valuesFile)
+		}
+	}
+
+	if p.Config.Namespace != "" {
+		lint = append(lint, "--namespace")
+		lint = append(lint, p.Config.Namespace)
+	}
+
+	if p.Config.TillerNs != "" {
+		lint = append(lint, "--tiller-namespace")
+		lint = append(lint, p.Config.TillerNs)
+	}
+
+	if p.Config.Debug {
+		lint = append(lint, "--debug")
+	}
+
+	p.command = lint
 }
 
 func setHelmCommand(p *Plugin) {
@@ -149,6 +187,8 @@ func setHelmCommand(p *Plugin) {
 		setUpgradeCommand(p)
 	case "delete":
 		setDeleteCommand(p)
+	case "lint":
+		setLintCommand(p)
 	default:
 		switch os.Getenv("DRONE_BUILD_EVENT") {
 		case "push", "tag", "deployment", "pull_request", "promote", "rollback":

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -171,6 +171,30 @@ func TestGetHelmDeleteCommand(t *testing.T) {
 	}
 }
 
+func TestGetHelmCommandLint(t *testing.T) {
+	os.Setenv("DRONE_BUILD_EVENT", "push")
+	plugin := &Plugin{
+		Config: Config{
+			APIServer:     "http://myapiserver",
+			Token:         "secret-token",
+			HelmCommand:   "lint",
+			Namespace:     "default",
+			SkipTLSVerify: true,
+			Chart:         "./chart/test",
+			Values:        `"image.tag=v.0.1.0,nameOverride=my-over-app"`,
+			StringValues:  `"long_string_value=1234567890"`,
+		},
+	}
+	setHelmCommand(plugin)
+	res := strings.Join(plugin.command[:], " ")
+	expected := "lint ./chart/test --set image.tag=v.0.1.0,nameOverride=my-over-app --set-string long_string_value=1234567890 --namespace default"
+	if res != expected {
+		t.Errorf("Result is %s and we expected %s", res, expected)
+	}
+}
+
+
+
 func TestGetHelmDeleteCommandOverried(t *testing.T) {
 	os.Setenv("DRONE_BUILD_EVENT", "deployment")
 	plugin := &Plugin{


### PR DESCRIPTION
Add the "helm lint" command because it can be used in pull-request builds to verify a chart *before* it gets merged to master.

Fixes #85.