### PR TITLE
Add a flag to use helm-secrets on upgrade/lint

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,6 +163,11 @@ func main() {
 			Usage:  "URL for stable repository (default 'https://kubernetes-charts.storage.googleapis.com')",
 			EnvVar: "PLUGIN_STABLE_REPO_URL,STABLE_REPO_URL",
 		},
+		cli.BoolFlag{
+			Name:   "helm_secrets",
+			Usage:  "use the helm-secrets plugin for lint and upgrade commands",
+			EnvVar: "PLUGIN_HELM_SECRETS,HELM_SECRETS",
+		},
 	}
 	if err := app.Run(os.Args); err != nil {
 		logrus.Fatal(err)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -51,6 +51,7 @@ type (
 		Purge              bool     `json:"purge"`
 		UpdateDependencies bool     `json:"update_dependencies"`
 		StableRepoURL      string   `json:"stable_repo_url"`
+		HelmSecrets        bool     `json:"helm_secrets"`
 	}
 	// Plugin default
 	Plugin struct {
@@ -138,6 +139,9 @@ func setUpgradeCommand(p *Plugin) {
 	if p.Config.Force {
 		upgrade = append(upgrade, "--force")
 	}
+	if p.Config.HelmSecrets {
+		upgrade = append([]string{"secrets"}, upgrade...)
+	}
 	p.command = upgrade
 }
 
@@ -175,6 +179,10 @@ func setLintCommand(p *Plugin) {
 
 	if p.Config.Debug {
 		lint = append(lint, "--debug")
+	}
+
+	if p.Config.HelmSecrets {
+		lint = append([]string{"secrets"}, lint...)
 	}
 
 	p.command = lint

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -116,6 +116,37 @@ func TestGetHelmCommandEmptyPushEvent(t *testing.T) {
 	}
 }
 
+func TestGetHelmCommandSecretsUpgrade(t *testing.T) {
+	os.Setenv("DRONE_BUILD_EVENT", "push")
+	plugin := &Plugin{
+		Config: Config{
+			APIServer:     "http://myapiserver",
+			Token:         "secret-token",
+			HelmCommand:   "upgrade",
+			Namespace:     "default",
+			SkipTLSVerify: true,
+			Debug:         true,
+			DryRun:        true,
+			Chart:         "./chart/test",
+			Version:       "1.2.3",
+			Release:       "test-release",
+			Values:        `"image.tag=v.0.1.0,nameOverride=my-over-app"`,
+			StringValues:  `"long_string_value=1234567890"`,
+			Wait:          true,
+			ReuseValues:   true,
+			Timeout:       "500",
+			Force:         true,
+      HelmSecrets:   true,
+		},
+	}
+	setHelmCommand(plugin)
+	res := strings.Join(plugin.command[:], " ")
+	expected := "secrets upgrade --install test-release ./chart/test --version 1.2.3 --set image.tag=v.0.1.0,nameOverride=my-over-app --set-string long_string_value=1234567890 --namespace default --dry-run --debug --wait --reuse-values --timeout 500 --force"
+	if res != expected {
+		t.Errorf("Result is %s and we expected %s", res, expected)
+	}
+}
+
 func TestGetHelmCommandUpgrade(t *testing.T) {
 	os.Setenv("DRONE_BUILD_EVENT", "push")
 	plugin := &Plugin{
@@ -193,7 +224,28 @@ func TestGetHelmCommandLint(t *testing.T) {
 	}
 }
 
-
+func TestGetHelmCommandSecretsLint(t *testing.T) {
+	os.Setenv("DRONE_BUILD_EVENT", "push")
+	plugin := &Plugin{
+		Config: Config{
+			APIServer:     "http://myapiserver",
+			Token:         "secret-token",
+			HelmCommand:   "lint",
+			Namespace:     "default",
+			SkipTLSVerify: true,
+			Chart:         "./chart/test",
+			Values:        `"image.tag=v.0.1.0,nameOverride=my-over-app"`,
+			StringValues:  `"long_string_value=1234567890"`,
+      HelmSecrets:   true,
+		},
+	}
+	setHelmCommand(plugin)
+	res := strings.Join(plugin.command[:], " ")
+	expected := "secrets lint ./chart/test --set image.tag=v.0.1.0,nameOverride=my-over-app --set-string long_string_value=1234567890 --namespace default"
+	if res != expected {
+		t.Errorf("Result is %s and we expected %s", res, expected)
+	}
+}
 
 func TestGetHelmDeleteCommandOverried(t *testing.T) {
 	os.Setenv("DRONE_BUILD_EVENT", "deployment")


### PR DESCRIPTION
This depends on #92 for installation of the associated plugin. 

Reminder: this will probably fail spectacularly if you haven't built the
(drone) plugin with the (helm) plugin.