### PR TITLE
support for multiple pre-baked kube/helm versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.12-alpine3.9 as builder
 RUN apk update
 RUN apk add dep git
 
-ENV GOOS linux 
+ENV GOOS=linux 
 ENV GOARCH=386 
 
 WORKDIR /go/src/github.com/ipedrazas/drone-helm
@@ -22,30 +22,18 @@ FROM alpine:3.9 as final
 MAINTAINER Ivan Pedrazas <ipedrazas@gmail.com>
 
 COPY --from=builder /go/src/github.com/ipedrazas/drone-helm/drone-helm /bin/
-
-# Helm version: can be passed at build time
-ARG VERSION
-ENV VERSION ${VERSION:-v2.14.1}
-ENV FILENAME helm-${VERSION}-linux-amd64.tar.gz
-
-ARG KUBECTL
-ENV KUBECTL ${KUBECTL:-v1.14.3}
+COPY  *.sh /bin/
+COPY kubeconfig /root/.kube/kubeconfig
 
 RUN set -ex \
-  && apk add --no-cache curl ca-certificates \
-  && curl -o /tmp/${FILENAME} http://storage.googleapis.com/kubernetes-helm/${FILENAME} \
-  && curl -o /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL}/bin/linux/amd64/kubectl \
+  && apk add --no-cache curl ca-certificates bash \
   && curl -o /tmp/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator \
-  && tar -zxvf /tmp/${FILENAME} -C /tmp \
-  && mv /tmp/linux-amd64/helm /bin/helm \
-  && chmod +x /tmp/kubectl \
-  && mv /tmp/kubectl /bin/kubectl \
   && chmod +x /tmp/aws-iam-authenticator \
-  && mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator \
-  && rm -rf /tmp/*
+  && mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator 
+RUN PREFIX=/ /bin/setup-environments.sh
+RUN rm -rf /tmp/*
 
 LABEL description="Kubectl and Helm."
 LABEL base="alpine"
-COPY kubeconfig /root/.kube/kubeconfig
 
-ENTRYPOINT [ "/bin/drone-helm" ]
+ENTRYPOINT [ "/bin/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Will symlink `helm` and `kubectl` binaries based on the `$HELM_VERSION` and
+# `$KUBECTL_VERSION` env variables into `$PREFIX/bin`, add `$PREFIX/bin` to 
+# the `$PATH` and delegate further execution to `/bin/drone-helm`
+# See `set-environments.sh` for baked in versions.
+
+PREFIX=~/.local
+HELM_VERSION="${HELM_VERSION:-v2.14.1}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-v1.14.3}"
+
+mkdir -p ${PREFIX}/bin
+ln -s -f ${PREFIX}/lib/helm-${HELM_VERSION}/helm ${prefix}/bin
+ln -s -f ${PREFIX}/lib/kubectl-${KUBECTL_VERSION}/kubectl ${prefix}/bin
+
+export PATH=${PREFIX}/bin:$PATH
+
+echo "Using helm    Version: ${HELM_VERSION}"
+echo "Using kubectl Version: ${KUBECTL_VERSION}"
+
+/bin/drone-helm "$@"

--- a/setup-environments.sh
+++ b/setup-environments.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+PREFIX=~/.local
+
+# will populate $PREFIX/lib/helm-$version/ with helm and tiller binaries
+helm_arch="linux-amd64"
+helm_versions=(v2.14.1 v2.13.1 v2.12.3)
+
+for version in "${helm_versions[@]}"
+do
+    curl http://storage.googleapis.com/kubernetes-helm/helm-${version}-${helm_arch}.tar.gz > /tmp/${version}.tar.gz
+    mkdir -p $PREFIX/lib/helm-${version}/
+    tar -C $PREFIX/lib/helm-${version}/ -xvf /tmp/${version}.tar.gz --strip 1
+done
+
+# will populate $PREFIX/lib/kubectl-$version/ with kubectl binaries
+kubectl_arch="linux/amd64"
+kubectl_versions=(v1.14.3 v1.13.7 v1.12.9)
+
+for version in "${kubectl_versions[@]}"
+do
+    mkdir -p $PREFIX/lib/kubectl-${version}/
+    curl https://storage.googleapis.com/kubernetes-release/release/${version}/bin/${kubectl_arch}/kubectl > $PREFIX/lib/kubectl-${version}/kubectl
+    chmod +x $PREFIX/lib/kubectl-${version}/kubectl
+done
+


### PR DESCRIPTION
Do not merge, this needs to be discussed.

I was toying with the idea to support multiple versions of `kubectl` and `helm` pre-baked into the docker image. `setup-environments.sh` will download the 3 latest major releases of each package and the `entrypoint.sh` "wrapper" will setup the `$PATH` based on the selected versions via `HELM_VERSION` and `KUBECTL_VERSION` environment  variables.

I have included the following versions in this PR:

helm:

* v2.14.1 
* v2.13.1 
* v2.12.3

kubectl:
* v1.14.3 
* v1.13.7 
* v1.12.9

use the plugin / image as usual and pass the `KUBECTL_VERSION` and `HELM_VERSION` environments according to the supported version list above.

A major drawback of this PR is the increased image size (122MB -> 486MB), therefore I am not that sure if this approach is sane. 

If it turns out that I am the only one here with concerns about that image size, I will gladly finish the PR by adding some sanity checks, documentation and refactor the versions to be configured externally. 
