### PR TITLE
Added atomic flag 

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,8 +154,8 @@ func main() {
 			EnvVar: "PLUGIN_PURGE,PURGE",
 		},
 		cli.BoolFlag{
-		    Name:   "atomic",
-		    Usage:  "if set, install/upgrade process rolls back or purges chart in case of failed install/upgrade"
+			Name:   "atomic",
+			Usage:  "if set, install/upgrade process rolls back or purges chart in case of failed install/upgrade",
 		}
 		cli.BoolFlag{
 			Name:   "update-dependencies",

--- a/main.go
+++ b/main.go
@@ -156,7 +156,8 @@ func main() {
 		cli.BoolFlag{
 			Name:   "atomic",
 			Usage:  "if set, install/upgrade process rolls back or purges chart in case of failed install/upgrade",
-		}
+			EnvVar: "PLUGIN_ATOMIC,ATOMIC",
+		},
 		cli.BoolFlag{
 			Name:   "update-dependencies",
 			Usage:  "update dependency charts based on the contents of requirements.yaml file of the local chart",

--- a/main.go
+++ b/main.go
@@ -154,6 +154,10 @@ func main() {
 			EnvVar: "PLUGIN_PURGE,PURGE",
 		},
 		cli.BoolFlag{
+		    Name:   "atomic",
+		    Usage:  "if set, install/upgrade process rolls back or purges chart in case of failed install/upgrade"
+		}
+		cli.BoolFlag{
 			Name:   "update-dependencies",
 			Usage:  "update dependency charts based on the contents of requirements.yaml file of the local chart",
 			EnvVar: "PLUGIN_UPDATE_DEPENDENCIES,UPDATE_DEPENDENCIES",
@@ -205,6 +209,7 @@ func run(c *cli.Context) error {
 			ReuseValues:        c.Bool("reuse-values"),
 			Timeout:            c.String("timeout"),
 			Force:              c.Bool("force"),
+			Atomic:             c.Bool("atomic"),
 			UpdateDependencies: c.Bool("update-dependencies"),
 			StableRepoURL:      c.String("stable_repo_url"),
 		},

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -140,7 +140,7 @@ func setUpgradeCommand(p *Plugin) {
 		upgrade = append(upgrade, "--force")
 	}
 	if p.Config.Atomic {
-	    upgrade = append(upgrade, "--atomic")
+		upgrade = append(upgrade, "--atomic")
 	}
 	p.command = upgrade
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -49,6 +49,7 @@ type (
 		Force              bool     `json:"force"`
 		HelmRepos          []string `json:"helm_repos"`
 		Purge              bool     `json:"purge"`
+		Atomic             bool     `json:"atomic"`
 		UpdateDependencies bool     `json:"update_dependencies"`
 		StableRepoURL      string   `json:"stable_repo_url"`
 	}
@@ -137,6 +138,9 @@ func setUpgradeCommand(p *Plugin) {
 	}
 	if p.Config.Force {
 		upgrade = append(upgrade, "--force")
+	}
+	if p.Config.Atomic {
+	    upgrade = append(upgrade, "--atomic")
 	}
 	p.command = upgrade
 }

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -106,11 +106,12 @@ func TestGetHelmCommandEmptyPushEvent(t *testing.T) {
 			ReuseValues:   true,
 			Timeout:       "500",
 			Force:         true,
+			Atomic:        true,
 		},
 	}
 	setHelmCommand(plugin)
 	res := strings.Join(plugin.command[:], " ")
-	expected := "upgrade --install test-release ./chart/test --version 1.2.3 --set image.tag=v.0.1.0,nameOverride=my-over-app --set-string long_string_value=1234567890 --namespace default --dry-run --debug --wait --reuse-values --timeout 500 --force"
+	expected := "upgrade --install test-release ./chart/test --version 1.2.3 --set image.tag=v.0.1.0,nameOverride=my-over-app --set-string long_string_value=1234567890 --namespace default --dry-run --debug --wait --reuse-values --timeout 500 --force --atomic"
 	if res != expected {
 		t.Errorf("Result is %s and we expected %s", res, expected)
 	}
@@ -136,11 +137,12 @@ func TestGetHelmCommandUpgrade(t *testing.T) {
 			ReuseValues:   true,
 			Timeout:       "500",
 			Force:         true,
+			Atomic:        true,
 		},
 	}
 	setHelmCommand(plugin)
 	res := strings.Join(plugin.command[:], " ")
-	expected := "upgrade --install test-release ./chart/test --version 1.2.3 --set image.tag=v.0.1.0,nameOverride=my-over-app --set-string long_string_value=1234567890 --namespace default --dry-run --debug --wait --reuse-values --timeout 500 --force"
+	expected := "upgrade --install test-release ./chart/test --version 1.2.3 --set image.tag=v.0.1.0,nameOverride=my-over-app --set-string long_string_value=1234567890 --namespace default --dry-run --debug --wait --reuse-values --timeout 500 --force --atomic"
 	if res != expected {
 		t.Errorf("Result is %s and we expected %s", res, expected)
 	}


### PR DESCRIPTION
The current drone-helm implementation has no way to purge or rollback failed deployments. The atomic flag can handle this situation and therefore I added it as an option.

On install:
`if set, installation process purges chart on fail, also sets --wait flag`

On upgrade:
`if set, upgrade process rolls back changes made in case of failed upgrade, also sets --wait flag`

In my opinion this is the way a CI/CD like Drone should be working in the first place.