### PR TITLE
Upgrade helm to 2.17.0 and kubectl to 1.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,11 @@ COPY --from=builder /go/src/github.com/ipedrazas/drone-helm/drone-helm /bin/
 
 # Helm version: can be passed at build time
 ARG VERSION
-ENV VERSION ${VERSION:-v2.14.1}
+ENV VERSION ${VERSION:-v2.17.0}
 ENV FILENAME helm-${VERSION}-linux-amd64.tar.gz
 
 ARG KUBECTL
-ENV KUBECTL ${KUBECTL:-v1.14.3}
+ENV KUBECTL ${KUBECTL:-v1.19.0}
 
 RUN set -ex \
   && apk add --no-cache curl ca-certificates \

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 This plugin allows to deploy a [Helm](https://github.com/kubernetes/helm) chart into a [Kubernetes](https://github.com/kubernetes/kubernetes) cluster.
 
-* Current `helm` version: 2.14.1
-* Current `kubectl` version: 1.14.3
+* Current `helm` version: 2.17.0
+* Current `kubectl` version: 1.19.0
 
 ## Drone Pipeline Usage
 
@@ -54,6 +54,6 @@ export ACTION=add
 
 This repo is setup in a way that if you enable a personal drone server to build your fork it will
  build and publish your image (makes it easier to test PRs and use the image till the contributions get merged)
- 
+
 * Build local ```DRONE_REPO_OWNER=ipedrazas DRONE_REPO_NAME=drone-helm drone exec```
 * on your server just make sure you have DOCKER_USERNAME, DOCKER_PASSWORD, and DOCKERHUB_REPO set as secrets


### PR DESCRIPTION
Hi, this pull request bumps Helm to 2.17.0 and kubectl to 1.19.0.

The Helm upgrade is particularly important since 2.14.1 still uses API that was deprecate in kubernetes 1.15 (and Google recently force updated all GKE clusters, so currently all our builds fail).

This is the issue in Helm repository describing the problem: https://github.com/helm/helm/issues/6374
And this is the pull request with the solution (linking directly to a comment saying in which version the fix is to be released): https://github.com/helm/helm/pull/6462#issuecomment-549166815

Kubectl was upgraded just because the new version is available (if that is the problem, then I can prepare a commit without bumping kubectl).

I'd be really, really glad for merging this (and updating quay.io). Thanks!