### PR TITLE
Change default url for stable_repo_url

### DIFF
--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:   "stable_repo_url",
-			Usage:  "URL for stable repository (default 'https://kubernetes-charts.storage.googleapis.com')",
+			Usage:  "URL for stable repository (default 'https://charts.helm.sh/stable')",
 			EnvVar: "PLUGIN_STABLE_REPO_URL,STABLE_REPO_URL",
 		},
 	}


### PR DESCRIPTION
The old repo url (https://kubernetes-charts.storage.googleapis.co) does not resolve causing build failures. 

Changing default value as recommended [here](https://github.com/hashicorp/terraform-provider-helm/issues/649)
